### PR TITLE
Portability and ease of use changes to shell scripts

### DIFF
--- a/Process/cook-data.sh
+++ b/Process/cook-data.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # needs four arguments: a tree and a set of barcodes, a time scaling factor, and loss/gain (1/0)
 # the tree should be in Newick format
 # the barcodes should be in CSV format with the sample name as the first column, with one header row

--- a/Process/mro-timetree-parse.sh
+++ b/Process/mro-timetree-parse.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # the TimeTree database doesn't hold all our species of interest
 # this code addresses this with two approaches -- first, using close relatives; and second, manually adding species with uncertain divergence times
 

--- a/Scripts/infer-others.sh
+++ b/Scripts/infer-others.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # run HyperTraPS for various existing scientific case studies
 
 # get back to root

--- a/Scripts/infer-others.sh
+++ b/Scripts/infer-others.sh
@@ -6,17 +6,40 @@ cd ..
 
 gcc -o3 hypertraps.c -lm -o hypertraps.ce
 
+# Clears all command line arguments passed to the scripts, required to save pids
+set --
+
 # C4 via MCMC, PLI, SA
 ./hypertraps.ce --obs Data/c4-curated.csv --length 4 --kernel 4 --label Data/c4-ht > Data/c4-ht.tmp &
+set -- "$@" $! # Append the previous process id to args
 ./hypertraps.ce --obs Data/c4-curated.csv --length 4 --kernel 4 --pli --label Data/c4-pli --walkers 5000 > Data/c4-pli.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/c4-curated.csv --length 4 --kernel 4 --sa --label Data/c4-sa > Data/c4-sa.tmp &
+set -- "$@" $!
 
 # ovarian cancer via MCMC, PLI, SA
 ./hypertraps.ce --obs Data/ovarian.txt --length 4 --kernel 4 --label Data/ovarian-ht > Data/ovarian-ht.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ovarian.txt --length 4 --kernel 4 --pli --label Data/ovarian-pli > Data/ovarian-pli.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ovarian.txt --length 4 --kernel 4 --sa --label Data/ovarian-sa > Data/ovarian-sa.tmp &
+set -- "$@" $!
 
 # other others
 ./hypertraps.ce --obs Data/jallow_dataset_binary_with2s.csv --outputtransitions 0 --walkers 2 --kernel 3 --label Data/malaria > Data/malaria.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/jallow_dataset_binary_with2s.csv --outputtransitions 0 --walkers 2 --kernel 3 --label Data/malaria-sa --sa > Data/malaria-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/total-observations.txt-trans.txt --label Data/tools --transitionformat--length 4 --kernel 4 > Data/tools.tmp &
+set -- "$@" $!
+
+echo Running $# instances of HyperTraPS as subprocesses
+echo Waiting for all subprocesses to finish
+echo PIDS: $@
+
+# Wait for all subprocess created by this script to return
+for job in $@
+do
+	wait $job
+	echo $job finished
+done

--- a/Scripts/infer-tb.sh
+++ b/Scripts/infer-tb.sh
@@ -7,20 +7,46 @@ cd ..
 
 gcc -o3 hypertraps.c -lm -o hypertraps.ce
 
+# Clears all command line arguments passed to the scripts, required to save pids
+set --
+
 # discrete time approaches
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --seed 1 --transitionformat --length 5 --kernel 4 --label Data/tb-dt-1 > Data/tb-dt-1.tmp &
+set -- "$@" $! # Append the previous process id to args
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --seed 2 --transitionformat --length 5 --kernel 4 --label Data/tb-dt-2 > Data/tb-dt-2.tmp &
+set -- "$@" $!
 # non-MCMC
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --seed 1 --transitionformat --length 5 --kernel 4 --label Data/tb-dt-sa --sa > Data/tb-dt-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --seed 1 --transitionformat --length 5 --kernel 4 --label Data/tb-dt-sgd --sgd > Data/tb-dt-sgd.tmp &
+set -- "$@" $!
 
 # continuous time approaches
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 1 --transitionformat --length 6 --kernel 4 --label Data/tb-ct-1 > Data/tb-ct-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 2 --transitionformat --length 6 --kernel 4 --label Data/tb-ct-2 > Data/tb-ct-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 1 --transitionformat --length 7 --kernel 4 --label Data/tb-ct-a-1 > Data/tb-ct-a-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 2 --transitionformat --length 7 --kernel 4 --label Data/tb-ct-a-2 > Data/tb-ct-a-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 1 --transitionformat --length 6 --kernel 5 --label Data/tb-ct-b-1 > Data/tb-ct-b-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 2 --transitionformat --length 6 --kernel 5 --label Data/tb-ct-b-2 > Data/tb-ct-b-2.tmp &
+set -- "$@" $!
 # non-MCMC
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 1 --transitionformat --length 5 --kernel 5 --label Data/tb-ct-sa --sa > Data/tb-ct-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs Data/ng.2878-S2.txt-cooked.txt-data.txt --starttimes Data/ng.2878-S2.txt-cooked.txt-datatime.txt --seed 1 --transitionformat --length 5 --kernel 5 --label Data/tb-ct-sgd --sgd > Data/tb-ct-sgd.tmp &
+set -- "$@" $!
+
+echo Running $# instances of HyperTraPS as subprocesses
+echo Waiting for all subprocesses to finish
+echo PIDS: $@
+
+# Wait for all subprocess created by this script to return
+for job in $@
+do
+	wait $job
+	echo $job finished
+done

--- a/Scripts/infer-tb.sh
+++ b/Scripts/infer-tb.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # infer TB evolutionary dynamics
 # ensure prepare-all.sh has been run to wrangle data
 

--- a/Scripts/infer-tests.sh
+++ b/Scripts/infer-tests.sh
@@ -18,73 +18,135 @@ cd ..
 
 gcc -o3 hypertraps.c -lm -o hypertraps.ce
 
+# Clears all command line arguments passed to the scripts, required to save pids
+set --
+
 ## discrete time
 # different sampling walkers
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-1 > VerifyData/t-simple-1.tmp &
+set -- "$@" $! # Append the previous process id to args
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-2 --walkers 2000 > VerifyData/t-simple-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-3 --walkers 20 > VerifyData/t-simple-3.tmp &
+set -- "$@" $!
 # different optimisers
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-sa --sa > VerifyData/t-simple-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-sgd --sgd > VerifyData/t-simple-sgd.tmp &
+set -- "$@" $!
 # different parameter structures
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod--1 --model -1 > VerifyData/t-simple-mod--1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod-0 --model 0 > VerifyData/t-simple-mod-0.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod-1 --model 1 > VerifyData/t-simple-mod-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod-2 --model 2 > VerifyData/t-simple-mod-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod-3 --model 3 > VerifyData/t-simple-mod-3.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod-4 --model 4 > VerifyData/t-simple-mod-4.tmp &
+set -- "$@" $!
 
 ## different parameter space sizes
 # cross-cube observations
 ./hypertraps.ce --obs VerifyData/synth-bigcross-10-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-10 > VerifyData/t-bigcross-hard-10.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-30-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-30 > VerifyData/t-bigcross-hard-30.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-50-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-50 > VerifyData/t-bigcross-hard-50.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-70-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-70 > VerifyData/t-bigcross-hard-70.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-90-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-90 > VerifyData/t-bigcross-hard-90.tmp &
+set -- "$@" $!
 # cross-cube with different single-walker optimisers
 ./hypertraps.ce --obs VerifyData/synth-bigcross-90-hard-samples.txt --transitionformat --length 5 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-90-1 --walkers 1 > VerifyData/t-bigcross-hard-90-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-90-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-90-1-sa --sa --walkers 1 > VerifyData/t-bigcross-hard-90-1-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-90-hard-samples.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-90-1-sgd --sgd --walkers 1 > VerifyData/t-bigcross-hard-90-1-sgd.tmp &
+set -- "$@" $!
 
 ### regularisation demo
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt -lscale 100 --sa --transitionformat --length 4 --label VerifyData/test-cross-mod--1-sa --model -1 --regularise > VerifyData/t-simple-mod--1-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt -lscale 100 --sa --transitionformat --length 4 --label VerifyData/test-cross-mod-2-sa --model 2 --regularise > VerifyData/t-simple-mod-2-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt -lscale 100 --sa --transitionformat --length 4 --label VerifyData/test-cross-mod-3-sa --model 3 --regularise > VerifyData/t-simple-mod-3-sa.tmp &
+set -- "$@" $!
 
 # PLI
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --length 4 --label VerifyData/test-cross-mod-2-pli --pli --walkers 200 > t-pli.tmp &
+set -- "$@" $!
 
 ### discrete time hi-order logic problem
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 4 --label VerifyData/test-ho-mod--1 --model -1 > VerifyData/t-ho-mod--1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 4 --label VerifyData/test-ho-mod-2 --model 2 > VerifyData/t-ho-mod-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 4 --label VerifyData/test-ho-mod-3 --model 3 > VerifyData/t-ho-mod-3.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 5 --label VerifyData/test-ho-mod--1-l --model -1 > VerifyData/t-ho-mod--1-l.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 5 --label VerifyData/test-ho-mod-2-l --model 2 > VerifyData/t-ho-mod-2-l.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 5 --label VerifyData/test-ho-mod-3-l --model 3 > VerifyData/t-ho-mod-3-l.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 5 --sa --label VerifyData/test-ho-mod--1-sa --model -1 > VerifyData/t-ho-mod--1-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 5 --sa --label VerifyData/test-ho-mod-2-sa --model 2 > VerifyData/t-ho-mod-2-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/hi-order.txt --lscale 10 --transitionformat --length 5 --sa --label VerifyData/test-ho-mod-3-sa --model 3 > VerifyData/t-ho-mod-3-sa.tmp &
+set -- "$@" $!
 
 ## continuous time
 # different sampling walkers
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-1 > VerifyData/t-simple-ct-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --walkers 2000 --label VerifyData/test-cross-ct-2 > VerifyData/t-simple-ct-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --walkers 20 --label VerifyData/test-cross-ct-3 > VerifyData/t-simple-ct-3.tmp &
+set -- "$@" $!
 # different optimisers
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-sa --sa > VerifyData/t-simple-ct-sa.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-sgd --sgd > VerifyData/t-simple-ct-sgd.tmp &
+set -- "$@" $!
 # different parameter structures
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-mod--1 --model -1 > VerifyData/t-simple-ct-mod--1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-mod-0 --model 0 > VerifyData/t-simple-ct-mod-0.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-mod-1 --model 1 > VerifyData/t-simple-ct-mod-1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-mod-2 --model 2 > VerifyData/t-simple-ct-mod-2.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-mod-3 --model 3 > VerifyData/t-simple-ct-mod-3.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --starttimes VerifyData/synth-cross-times-1.txt --transitionformat --length 4 --label VerifyData/test-cross-ct-mod-4 --model 4 > VerifyData/t-simple-ct-mod-4.tmp &
+set -- "$@" $!
 
 ## different parameter space sizes
 # cross-cube observations
 ./hypertraps.ce --obs VerifyData/synth-bigcross-10-hard-samples.txt --starttimes VerifyData/synth-bigcross-10-hard-times.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-ct-10 > VerifyData/t-bigcross-hard-ct-10.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-30-hard-samples.txt --starttimes VerifyData/synth-bigcross-30-hard-times.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-ct-30 > VerifyData/t-bigcross-hard-ct-30.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-50-hard-samples.txt --starttimes VerifyData/synth-bigcross-50-hard-times.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-ct-50 > VerifyData/t-bigcross-hard-ct-50.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-70-hard-samples.txt --starttimes VerifyData/synth-bigcross-70-hard-times.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-ct-70 > VerifyData/t-bigcross-hard-ct-70.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-bigcross-90-hard-samples.txt --starttimes VerifyData/synth-bigcross-90-hard-times.txt --transitionformat --length 4 --outputtransitions 0 --kernel 3 --label VerifyData/test-bigcross-hard-ct-90 > VerifyData/t-bigcross-hard-ct-90.tmp &
+set -- "$@" $!
+
+echo Running $# instances of HyperTraPS as subprocesses
+echo Waiting for all subprocesses to finish
+echo PIDS: $@
+
+# Wait for all subprocess created by this script to return
+for job in $@
+do
+        wait $job
+        echo $job finished
+done

--- a/Scripts/infer-tests.sh
+++ b/Scripts/infer-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # perform various more technical tests about optimisation and convergence for different sampling and optimisation schemes
 
 # get back to root

--- a/Scripts/infer-verify.sh
+++ b/Scripts/infer-verify.sh
@@ -23,12 +23,31 @@ cd ..
 # compile and run hypertraps code
 gcc -o3 hypertraps.c -lm -o hypertraps.ce
 
+# Clears all command line arguments passed to the scripts, required to save pids
+set --
+
 # two-pathway ("cross") case studies
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-0.txt --transitionformat --starttimes VerifyData/synth-cross-times-0.txt --seed 1 --length 4 --kernel 5 --label VerifyData/cross-0 > VerifyData/cross0.tmp &
+set -- "$@" $! # Append the previous process id to args
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-1.txt --transitionformat --starttimes VerifyData/synth-cross-times-1.txt --seed 1 --length 4 --kernel 5 --label VerifyData/cross-1 > VerifyData/cross1.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-cross-samples-2.txt --transitionformat --starttimes VerifyData/synth-cross-times-2.txt --seed 1 --length 4 --kernel 5 --label VerifyData/cross-2 > VerifyData/cross2.tmp &
+set -- "$@" $!
 
 # specific L=3 cubes with easy and hard parameterisations
 ./hypertraps.ce --obs VerifyData/synth-easycube-data.txt --transitionformat --starttimes VerifyData/synth-easycube-time.txt --seed 1 --length 4 --kernel 5 --label VerifyData/easycube > VerifyData/easycube.tmp &
+set -- "$@" $!
 ./hypertraps.ce --obs VerifyData/synth-hardcube-data.txt --transitionformat --starttimes VerifyData/synth-hardcube-time.txt --seed 1 --length 4 --kernel 5 --label VerifyData/hardcube > VerifyData/hardcube.tmp &
+set -- "$@" $!
+
+echo Running $# instances of HyperTraPS as subprocesses
+echo Waiting for all subprocesses to finish
+echo PIDS: $@
+
+# Wait for all subprocess created by this script to return
+for job in $@
+do
+        wait $job
+        echo $job finished
+done
 

--- a/Scripts/infer-verify.sh
+++ b/Scripts/infer-verify.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # get back to root
 cd ..
 

--- a/Scripts/prepare-all.sh
+++ b/Scripts/prepare-all.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # prepare and wrangle data for TB case study
 
 # get back to root


### PR DESCRIPTION
Minor additions to the shell scripts.
 - Add '#!/usr/bin/env bash' at the top for increased portability
 - Wait on all forked calls of our HyperTraPS runs
 - Print out a list of process IDs for signalling by the user